### PR TITLE
Remove race caused by MeasurementReader.receivedNewMeasurments

### DIFF
--- a/sttp/MeasurementReader.go
+++ b/sttp/MeasurementReader.go
@@ -51,8 +51,8 @@ func (mr *MeasurementReader) NextMeasurement() *transport.Measurement {
 }
 
 func (mr *MeasurementReader) receivedNewMeasurements(measurements []transport.Measurement) {
-	for _, measurement := range measurements {
-		mr.current <- &measurement
+	for i := range measurements {
+		mr.current <- &measurements[i]
 	}
 }
 


### PR DESCRIPTION
In go, within a 'for index, value := range arr' block, the 'value'
is not stable. The runtime uses a single area of memory and overwrites
that area upon the next iteration of the loop. By sending that address
over the channel, the value will get overridden by the next iteration
and change underfoot of the client.