### PR TITLE
disable protocol validation check before sending a Subscribe()

### DIFF
--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -98,9 +98,14 @@ func IsLeapSecond(ticks Ticks) bool {
 	return (ticks & LeapSecondFlag) > 0
 }
 
-// SetLeapSecond flags a Ticks value to represent a leap second, i.e., second 60, before wire serialization.
+// SetLeapSecond returns a copy of this Ticks value flagged to represent a leap second, i.e., second 60, before wire serialization.
 func SetLeapSecond(ticks Ticks) Ticks {
 	return ticks | LeapSecondFlag
+}
+
+// ApplyLeapSecond updates this Ticks value to represent a leap second, i.e., second 60, before wire serialization.
+func (t *Ticks) ApplyLeapSecond() {
+	*t |= LeapSecondFlag
 }
 
 // IsNegativeLeapSecond determines if the deserialized Ticks value represents a negative leap second, i.e., checks flag on second 58 to see if second 59 will be missing.
@@ -108,9 +113,14 @@ func IsNegativeLeapSecond(ticks Ticks) bool {
 	return IsLeapSecond(ticks) && (ticks&LeapSecondDirection) > 0
 }
 
-// SetNegativeLeapSecond flags a Ticks value to represent a negative leap second, i.e., sets flag on second 58 to mark that second 59 will be missing, before wire serialization.
+// SetNegativeLeapSecond returns a copy of this Ticks value flagged to represent a negative leap second, i.e., sets flag on second 58 to mark that second 59 will be missing, before wire serialization.
 func SetNegativeLeapSecond(ticks Ticks) Ticks {
 	return ticks | LeapSecondFlag | LeapSecondDirection
+}
+
+// ApplyNegativeLeapSecond updates this Ticks value to represent a negative leap second, i.e., sets flag on second 58 to mark that second 59 will be missing, before wire serialization.
+func (t *Ticks) ApplyNegativeLeapSecond() {
+	*t |= LeapSecondFlag | LeapSecondDirection
 }
 
 // Now gets the current local time as a Ticks value.

--- a/sttp/transport/DataSubscriber.go
+++ b/sttp/transport/DataSubscriber.go
@@ -447,9 +447,10 @@ func (ds *DataSubscriber) Subscribe() error {
 		return errors.New("subscriber is not connected; cannot subscribe")
 	}
 
-	if ds.validated.IsNotSet() {
-		return errors.New("subscriber is not validated; cannot subscribe")
-	}
+//	FIXME: when we want to subscribe, we're not yet validated; we need the subscription to validate us!
+//	if ds.validated.IsNotSet() {
+//		return errors.New("subscriber is not validated; cannot subscribe")
+//	}
 
 	// Make sure to unsubscribe before attempting another
 	// subscription so we don't leave UDP sockets open

--- a/sttp/transport/DataSubscriber.go
+++ b/sttp/transport/DataSubscriber.go
@@ -290,7 +290,8 @@ func (ds *DataSubscriber) LookupMetadata(signalID guid.Guid) *MeasurementMetadat
 			SignalID:   signalID,
 			Multiplier: 1.0,
 		}
-		ds.measurementRegistry.Store(signalID, metadata)
+		// Continue using LoadOrStore on failure to avoid racing another thread
+		ds.measurementRegistry.LoadOrStore(signalID, metadata)
 	}
 	return metadata.(*MeasurementMetadata)
 }

--- a/sttp/transport/DataSubscriber.go
+++ b/sttp/transport/DataSubscriber.go
@@ -190,6 +190,8 @@ func NewDataSubscriber() *DataSubscriber {
 		signalIndexCache:         [2]*SignalIndexCache{NewSignalIndexCache(), NewSignalIndexCache()},
 	}
 
+	ds.validated.Set()
+
 	ds.connectionTerminationThread = thread.NewThread(func() {
 		ds.disconnect(false, true, false)
 	})
@@ -236,7 +238,7 @@ func (ds *DataSubscriber) IsConnected() bool {
 
 // IsValidated determines if a DataSubscriber connection has been validated as an STTP connection.
 func (ds *DataSubscriber) IsValidated() bool {
-	return ds.validated.IsSet()
+	return true
 }
 
 // IsListening determines if a DataSubscriber is currently listening for a DataPublisher


### PR DESCRIPTION
Creating a datasubscribe with AutoRequestMetadata disabled has been broken since 506f15d7f811854ca03a975969b1aea9e6a709e5, which added the reverse connection support. The connection is not validated when we go to Subscribe(), and so the subscribe does not get sent, and the response does not get received, so the connection is not marked as valid.

We've been hacking around this by using AutoRequestMetadata even where it's unwanted, but we have reason to believe that having that enabled on the data worker may be inflating RAM usage.

I don't think this is the correct solution; it's probably better to have the no-op Subscribe response result in the connection being considered valid? Posting this only to begin that discussion :)