### PR TITLE
optimization: avoid heap allocation

### DIFF
--- a/sttp/transport/DataSubscriber.go
+++ b/sttp/transport/DataSubscriber.go
@@ -278,10 +278,19 @@ func (ds *DataSubscriber) DecodeString(data []byte) string {
 // LookupMetadata gets the MeasurementMetadata for the specified signalID from the local
 // registry. If the metadata does not exist, a new record is created and returned.
 func (ds *DataSubscriber) LookupMetadata(signalID guid.Guid) *MeasurementMetadata {
-	metadata, _ := ds.measurementRegistry.LoadOrStore(signalID, &MeasurementMetadata{
-		SignalID:   signalID,
-		Multiplier: 1.0,
-	})
+	// Intentionally avoids LoadOrStore, so as to avoid constructing the
+	// measurementmetadata during a lookup.
+	// Otherwise, the heap allocation an unused object ends up applying GC pressure
+	// and burning CPU.
+	metadata, ok := ds.measurementRegistry.Load(signalID)
+	if !ok {
+		metadata = &MeasurementMetadata{
+			SignalID:   signalID,
+			Multiplier: 1.0,
+		}
+		// Continue using LoadOrStore on failure to avoid racing another thread
+		ds.measurementRegistry.LoadOrStore(signalID, metadata)
+	}
 	return metadata.(*MeasurementMetadata)
 }
 


### PR DESCRIPTION
Taking the pointer to an item created in scope in a way that it can escape the function in which it is contained requires putting it on the heap.

As such, `LoadOrStore(someMap, &Foo{})` constructs an unneeded item on every load. A single memory allocation isn't hugely expensive, but we have cases where LookupMetadata is called millions of times a second, and ends up allocating enough to be using nontrivial amounts of CPU, as well as applying GC pressure.