### PR TITLE
ticks: cleans up the implementation and adds an API for converting to Unix nanoseconds

### DIFF
--- a/sttp/Subscriber.go
+++ b/sttp/Subscriber.go
@@ -650,7 +650,7 @@ func (sb *Subscriber) handleDataStartTime(startTime ticks.Ticks) {
 	sb.beginCallbackSync()
 
 	if sb.dataStartTimeReceiver != nil {
-		sb.dataStartTimeReceiver(ticks.ToTime(startTime))
+		sb.dataStartTimeReceiver(startTime.ToTime())
 	}
 
 	sb.endCallbackSync()

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -152,6 +152,11 @@ func (t Ticks) SetLeapSecond() Ticks {
 	return SetLeapSecond(t)
 }
 
+// Converts the ticks value into a Unix nanoseconds timestamp
+func (t Ticks) ToUnixNs() uint64 {
+	return uint64(((t & ValueMask) - UnixBaseOffset) * 100)
+}
+
 // String returns the string form of a Ticks value, i.e., a standard date/time value. See TimeFormat.
 func (t Ticks) String() string {
 	return t.ToTime().Format(TimeFormat)

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -139,7 +139,7 @@ func UtcNow() Ticks {
 
 // ToTime converts a Ticks value to standard Go Time value.
 func (t Ticks) ToTime() time.Time {
-	return ToTime(t)
+	return time.Unix(0, int64((t-UnixBaseOffset)&ValueMask)*100).UTC()
 }
 
 // IsLeapSecond determines if the deserialized Ticks value represents a leap second, i.e., second 60.

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -28,8 +28,7 @@ import (
 )
 
 // Ticks is a 64-bit integer used to designate time in STTP. The value represents the number of 100-nanosecond intervals
-// that have elapsed since 12:00:00 midnight, January 1, 0001 UTC, Gregorian calendar. A single tick represents one hundred
-// nanoseconds, or one ten-millionth of a second. There are 10,000 ticks in a millisecond and 10 million ticks in a second.
+// that have elapsed since 12:00:00 midnight, January 1, 0001 UTC, in the Gregorian calendar. A single tick represents 100ns.
 // Only bits 01 to 62 (0x3FFFFFFFFFFFFFFF) are used to represent the timestamp value. Bit 64 (0x8000000000000000) is used
 // to denote leap second, i.e., second 60, where actual second value would remain at 59. Bit 63 (0x4000000000000000) is
 // used to denote leap second direction, 0 for add, 1 for delete.

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -88,13 +88,13 @@ func ToTime(ticks Ticks) time.Time {
 }
 
 // Converts a unix nanoseconds timestamp into a Ticks value.
-func FromUnixNs(ns uint64) Ticks {
+func FromUnixNano(ns uint64) Ticks {
 	return Ticks(ns / 100) + UnixBaseOffset
 }
 
 // FromTime converts a standard Go Time value to a Ticks value.
 func FromTime(time time.Time) Ticks {
-	return FromUnixNs(uint64(time.UnixNano()))
+	return FromUnixNano(uint64(time.UnixNano()))
 }
 
 // IsLeapSecond determines if the deserialized Ticks value represents a leap second, i.e., second 60.
@@ -143,7 +143,7 @@ func (t Ticks) ToTime() time.Time {
 }
 
 // Converts the ticks value into a Unix nanoseconds timestamp
-func (t Ticks) ToUnixNs() uint64 {
+func (t Ticks) ToUnixNano() uint64 {
 	return uint64(((t & ValueMask) - UnixBaseOffset) * 100)
 }
 

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -16,6 +16,8 @@
 //
 //  Code Modification History:
 //  ----------------------------------------------------------------------------------------------------
+//  12.01.2024 - Noam Preil
+//       Add functions for working with Unix nanoseconds directly.
 //  09/09/2021 - J. Ritchie Carroll
 //       Generated original version of source code.
 //

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -87,6 +87,11 @@ func ToTime(ticks Ticks) time.Time {
 	return time.Unix(0, int64((ticks-UnixBaseOffset)&ValueMask)*100).UTC()
 }
 
+// Converts a unix nanoseconds timestamp into a Ticks value.
+func FromUnixNs(ns uint64) Ticks {
+	return Ticks(ns / 100) + UnixBaseOffset
+}
+
 // FromTime converts a standard Go Time value to a Ticks value.
 func FromTime(time time.Time) Ticks {
 	return (Ticks(time.UnixNano()/100) + UnixBaseOffset) & ValueMask

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -178,4 +178,3 @@ func (t *Ticks) SetLeapSecondDirection(negative bool) {
 func (t Ticks) IsNegativeLeapSecond() bool {
 	return t.IsLeapSecond() && (t&LeapSecondDirection) != 0
 }
-

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -94,7 +94,7 @@ func FromUnixNs(ns uint64) Ticks {
 
 // FromTime converts a standard Go Time value to a Ticks value.
 func FromTime(time time.Time) Ticks {
-	return (Ticks(time.UnixNano()/100) + UnixBaseOffset) & ValueMask
+	return FromUnixNs(uint64(time.UnixNano()))
 }
 
 // IsLeapSecond determines if the deserialized Ticks value represents a leap second, i.e., second 60.

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -30,8 +30,8 @@ import (
 // Ticks is a 64-bit integer used to designate time in STTP. The value represents the number of 100-nanosecond intervals
 // that have elapsed since 12:00:00 midnight, January 1, 0001 UTC, in the Gregorian calendar. A single tick represents 100ns.
 // Only bits 01 to 62 (0x3FFFFFFFFFFFFFFF) are used to represent the timestamp value. Bit 64 (0x8000000000000000) is used
-// to denote leap second, i.e., second 60, where actual second value would remain at 59. Bit 63 (0x4000000000000000) is
-// used to denote leap second direction, 0 for add, 1 for delete.
+// to denote a leap second, and bit 63 (0x4000000000000000) is used to denote the leap second's direction, 0 for add, 1 for delete.
+// Leap seconds are exposed, but are silently discarded upon conversion to Go or Unix timestamps.
 type Ticks uint64
 
 // Min is the minimum value for Ticks. It represents UTC time 01/01/0001 00:00:00.000.

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -142,16 +142,6 @@ func (t Ticks) ToTime() time.Time {
 	return time.Unix(0, int64((t-UnixBaseOffset)&ValueMask)*100).UTC()
 }
 
-// IsLeapSecond determines if the deserialized Ticks value represents a leap second, i.e., second 60.
-func (t Ticks) IsLeapSecond() bool {
-	return IsLeapSecond(t)
-}
-
-// SetLeapSecond flags a Ticks value to represent a leap second, i.e., second 60, before wire serialization.
-func (t Ticks) SetLeapSecond() Ticks {
-	return SetLeapSecond(t)
-}
-
 // Converts the ticks value into a Unix nanoseconds timestamp
 func (t Ticks) ToUnixNs() uint64 {
 	return uint64(((t & ValueMask) - UnixBaseOffset) * 100)
@@ -166,3 +156,24 @@ func (t Ticks) String() string {
 func (t Ticks) ShortTime() string {
 	return t.ToTime().Format(ShortTimeFormat)
 }
+
+func (t Ticks) IsLeapSecond() bool {
+	return (t&LeapSecondFlag) != 0
+}
+
+func (t *Ticks) SetLeapSecond(){
+	*t |= LeapSecondFlag
+}
+
+func (t *Ticks) SetLeapSecondDirection(negative bool) {
+	if negative {
+		*t |= LeapSecondDirection
+	} else {
+		*t &= ^LeapSecondDirection
+	}
+}
+
+func (t Ticks) IsNegativeLeapSecond() bool {
+	return t.IsLeapSecond() && (t&LeapSecondDirection) != 0
+}
+

--- a/sttp/ticks/Ticks.go
+++ b/sttp/ticks/Ticks.go
@@ -39,7 +39,7 @@ type Ticks uint64
 // Min is the minimum value for Ticks. It represents UTC time 01/01/0001 00:00:00.000.
 const Min Ticks = 0
 
-// Max is the maximum value for Ticks. It represents UTC time 12/31/1999 11:59:59.999.
+// Max is the maximum value for Ticks. It represents UTC time 12/31/9999 11:59:59.999.
 const Max Ticks = 3155378975999999999
 
 // PerSecond is the number of Ticks that occur in a second.

--- a/sttp/ticks/Ticks_test.go
+++ b/sttp/ticks/Ticks_test.go
@@ -53,7 +53,7 @@ func TestTicksTimeConversions(t *testing.T) {
 	}
 
 	ticks = 637669698432643641
-	timestamp = ToTime(ticks)
+	timestamp = ticks.ToTime()
 
 	if timestamp != time.Date(2021, 9, 11, 15, 10, 43, 264364100, time.UTC) {
 		t.Fatalf("TicksToTimeConversions: unexpected ToTime value conversion")

--- a/sttp/ticks/Ticks_test.go
+++ b/sttp/ticks/Ticks_test.go
@@ -39,7 +39,7 @@ func TestValidateTicksConstants(t *testing.T) {
 	if LeapSecondDirection != 0x4000000000000000 {
 		t.Fatalf("ValidateTicksConstants: unexpected ticks leap second direction flag value")
 	}
-	if UnixBaseOffset.ToUnixNs() != 0 {
+	if UnixBaseOffset.ToUnixNano() != 0 {
 		t.Fatalf("unix base offset is incorrect")
 	}
 }

--- a/sttp/ticks/Ticks_test.go
+++ b/sttp/ticks/Ticks_test.go
@@ -39,6 +39,9 @@ func TestValidateTicksConstants(t *testing.T) {
 	if LeapSecondDirection != 0x4000000000000000 {
 		t.Fatalf("ValidateTicksConstants: unexpected ticks leap second direction flag value")
 	}
+	if UnixBaseOffset.ToUnixNs() != 0 {
+		t.Fatalf("unix base offset is incorrect")
+	}
 }
 
 func TestTicksTimeConversions(t *testing.T) {

--- a/sttp/transport/DataSubscriber.go
+++ b/sttp/transport/DataSubscriber.go
@@ -1116,7 +1116,7 @@ func (ds *DataSubscriber) handleUpdateBaseTimes(data []byte) {
 
 	ds.baseTimeOffsets = baseTimeOffsets
 
-	timestamp, _ := ticks.ToTime(ticks.Ticks(ds.baseTimeOffsets[ds.timeIndex^1])).MarshalText()
+	timestamp, _ := ticks.Ticks(ds.baseTimeOffsets[ds.timeIndex^1]).ToTime().MarshalText()
 	ds.dispatchStatusMessage("Received new base time offset from publisher: " + string(timestamp))
 }
 


### PR DESCRIPTION
Go Time does not support leap seconds, so having the APIs for it doesn't really accomplish anything. A bunch of the constants are unused, so this also drops them.

This also adds APIs for converting directly to and from nanosecond timestamps, to allow bypassing go.Time intermediary conversion. Converting to and from Unix ns timestamps is just integer math; converting to and from Go timestamps requires branching and time zone conversions.

Also removes the comments on the leap flag bits, as whether bits start at 1 and 0 is contentious and nothing is actually using those fields except to define the valuemask, the math for which is straightforward bit manipulation.