### PR TITLE
DataTable: add optimized apis

### DIFF
--- a/sttp/data/DataColumn.go
+++ b/sttp/data/DataColumn.go
@@ -68,12 +68,6 @@ func (dc *DataColumn) Expression() string {
 	return dc.expression
 }
 
-// Computed gets a flag that determines if the DataColumn is a computed value,
-// i.e., has a defined expression.
-func (dc *DataColumn) Computed() bool {
-	return dc.computed
-}
-
 // Index gets the index of the DataColumn within its parent DataTable columns collection.
 func (dc *DataColumn) Index() int {
 	return dc.index

--- a/sttp/data/DataRow.go
+++ b/sttp/data/DataRow.go
@@ -86,7 +86,7 @@ func (dr *DataRow) validateColumnType(columnIndex, targetType int, read bool) (*
 		return nil, fmt.Errorf("cannot %s \"%s\" value %s DataColumn \"%s\" for table \"%s\", column data type is \"%s\"", action, DataTypeEnum(targetType).String(), preposition, column.Name(), dr.parent.Name(), column.Type().String())
 	}
 
-	if !read && column.Computed() {
+	if !read && column.computed {
 		return nil, errors.New("cannot assign value to DataColumn \"" + column.Name() + "\" for table \"" + dr.parent.Name() + "\", column is computed with an expression")
 	}
 
@@ -480,7 +480,7 @@ func (dr *DataRow) Value(columnIndex int) (interface{}, error) {
 		return nil, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		return dr.getComputedValue(column)
 	}
 
@@ -751,7 +751,7 @@ func (dr *DataRow) StringValue(columnIndex int) (string, bool, error) {
 		return "", false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -797,7 +797,7 @@ func (dr *DataRow) BooleanValue(columnIndex int) (bool, bool, error) {
 		return false, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -843,7 +843,7 @@ func (dr *DataRow) DateTimeValue(columnIndex int) (time.Time, bool, error) {
 		return time.Time{}, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -889,7 +889,7 @@ func (dr *DataRow) SingleValue(columnIndex int) (float32, bool, error) {
 		return 0.0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -935,7 +935,7 @@ func (dr *DataRow) DoubleValue(columnIndex int) (float64, bool, error) {
 		return 0.0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -981,7 +981,7 @@ func (dr *DataRow) DecimalValue(columnIndex int) (decimal.Decimal, bool, error) 
 		return decimal.Zero, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1027,7 +1027,7 @@ func (dr *DataRow) GuidValue(columnIndex int) (guid.Guid, bool, error) {
 		return guid.Guid{}, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1073,7 +1073,7 @@ func (dr *DataRow) Int8Value(columnIndex int) (int8, bool, error) {
 		return 0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1119,7 +1119,7 @@ func (dr *DataRow) Int16Value(columnIndex int) (int16, bool, error) {
 		return 0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1165,7 +1165,7 @@ func (dr *DataRow) Int32Value(columnIndex int) (int32, bool, error) {
 		return 0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1211,7 +1211,7 @@ func (dr *DataRow) Int64Value(columnIndex int) (int64, bool, error) {
 		return 0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1257,7 +1257,7 @@ func (dr *DataRow) UInt8Value(columnIndex int) (uint8, bool, error) {
 		return 0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1303,7 +1303,7 @@ func (dr *DataRow) UInt16Value(columnIndex int) (uint16, bool, error) {
 		return 0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1349,7 +1349,7 @@ func (dr *DataRow) UInt32Value(columnIndex int) (uint32, bool, error) {
 		return 0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {
@@ -1395,7 +1395,7 @@ func (dr *DataRow) UInt64Value(columnIndex int) (uint64, bool, error) {
 		return 0, false, err
 	}
 
-	if column.Computed() {
+	if column.computed {
 		value, err := dr.getComputedValue(column)
 
 		if err != nil {

--- a/sttp/data/DataRow.go
+++ b/sttp/data/DataRow.go
@@ -472,6 +472,14 @@ func convertFromDateTime(value time.Time, targetType DataTypeEnum) (interface{},
 	}
 }
 
+// Equivalent to Value, but asserts that the value is not computed, and
+// that the column index is valid. May crash if these assumptions are violated.
+// If the column comes from getColumnIndex, and is known to not be
+// computed, this should be safe.
+func (dr *DataRow) ValueFast(columnIndex int) (interface{}, error) {
+	return dr.values[columnIndex], nil
+}
+
 // Value reads the record value at the specified columnIndex.
 func (dr *DataRow) Value(columnIndex int) (interface{}, error) {
 	column, err := dr.validateColumnType(columnIndex, -1, true)

--- a/sttp/data/DataTable.go
+++ b/sttp/data/DataTable.go
@@ -130,6 +130,10 @@ func (dt *DataTable) InitRows(length int) {
 	dt.rows = make([]*DataRow, 0, length)
 }
 
+func (dt *DataTable) Rows() []*DataRow {
+	return dt.rows
+}
+
 // AddRow adds the specified row to the DataTable.
 func (dt *DataTable) AddRow(row *DataRow) {
 	dt.rows = append(dt.rows, row)


### PR DESCRIPTION
This adds two optimized APIs to the datatable interface to allow for faster access by the client.

There's two shortcomings with the existing APIs that require this:

- Finding the correct metadata row for each signal is O(N²)
- Looking up values by name is unusably slow, requires many allocations, and checks invariants that are guaranteed by the API to be true

To look at metadata for every signal, the current API requires a call to `RowsWhere`, which is effectively the same as:


```
for s := range signals {
    for s2 := range signals {
        if s2.signalid == s.signalid {
            return true
        }
    }
}
```

(This is simplified; in reality, we do not _have_ a full table of signals, and we look up each one, one at a time, as data comes in referencing the SignalID.)

That is, for each signal, we have to look at every single row, one at a time, to check if the row is correct.

The clear alternative is to simply process all metadata at once, looping over all rows. The current API allows for this using the RowCount() and Row(index) APIs, but Row(index) validates that the index is in range, and when the signal count is high, running another ~ten instructions per signal is wasteful.

Hence, expose the entire list of rows directly, to allow for direction iteration over it.

Similarly, accessing columns currently requires error checking even when the column index is returned _by the API_ and thus _already known to be valid_. Since each signal has many pieces of metadata, this problem is even worse, on the order of dozens of unnecessary comparisons and branches per signal. Moreover, in some cases, computed columns are known not to be in use, so checking them for every field is unnecessary.

As such, expose a ValueFast() API which bypasses this validation, to allow for faster lookups when the caller is willing to make additional guarantees that the normal API does not require.

Combined, using these two APIs in tandem is enough to drop the time to process metadata for a simulated grid environment with ~30k sensors from ~10 minutes to ~3 seconds.