### PR TITLE
Guid: optimize comparison functions

### DIFF
--- a/sttp/guid/Guid.go
+++ b/sttp/guid/Guid.go
@@ -27,7 +27,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"strconv"
-	"unsafe"
 
 	"github.com/google/uuid"
 )
@@ -45,25 +44,17 @@ func New() Guid {
 
 // IsZero determines if the Guid value is its zero value, i.e., empty.
 func (g Guid) IsZero() bool {
-	return Equal(g, Empty)
+	return g == Empty
 }
 
 // Equal returns true if this Guid and other Guid values are equal.
 func (g Guid) Equal(other Guid) bool {
-	a1 := (*uint64)(unsafe.Pointer(&g[0]))
-	a2 := (*uint64)(unsafe.Pointer(&g[8]))
-	b1 := (*uint64)(unsafe.Pointer(&other[0]))
-	b2 := (*uint64)(unsafe.Pointer(&other[8]))
-	return *a1 == *b1 && *a2 == *b2
+	return g == other
 }
 
 // Equal returns true if the a and b Guid values are equal.
 func Equal(a, b Guid) bool {
-	a1 := (*uint64)(unsafe.Pointer(&a[0]))
-	a2 := (*uint64)(unsafe.Pointer(&a[8]))
-	b1 := (*uint64)(unsafe.Pointer(&b[0]))
-	b2 := (*uint64)(unsafe.Pointer(&b[8]))
-	return *a1 == *b1 && *a2 == *b2
+	return a == b
 }
 
 // Compare returns an integer comparing this Guid (g) to other Guid. The result will be 0 if g==other, -1 if this g < other, and +1 if g > other.

--- a/sttp/guid/Guid.go
+++ b/sttp/guid/Guid.go
@@ -24,10 +24,10 @@
 package guid
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"strconv"
+	"unsafe"
 
 	"github.com/google/uuid"
 )
@@ -55,7 +55,11 @@ func (g Guid) Equal(other Guid) bool {
 
 // Equal returns true if the a and b Guid values are equal.
 func Equal(a, b Guid) bool {
-	return bytes.Equal(a[:], b[:])
+	a1 := (*uint64)(unsafe.Pointer(&a[0]))
+	a2 := (*uint64)(unsafe.Pointer(&a[8]))
+	b1 := (*uint64)(unsafe.Pointer(&b[0]))
+	b2 := (*uint64)(unsafe.Pointer(&b[8]))
+	return *a1 == *b1 && *a2 == *b2
 }
 
 // Compare returns an integer comparing this Guid (g) to other Guid. The result will be 0 if g==other, -1 if this g < other, and +1 if g > other.

--- a/sttp/guid/Guid.go
+++ b/sttp/guid/Guid.go
@@ -24,6 +24,7 @@
 package guid
 
 import (
+	"bytes"
 	"errors"
 	"strconv"
 
@@ -53,13 +54,7 @@ func (g Guid) Equal(other Guid) bool {
 
 // Equal returns true if the a and b Guid values are equal.
 func Equal(a, b Guid) bool {
-	for i := 0; i < 16; i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
+	return bytes.Equal(a[:], b[:])
 }
 
 // Compare returns an integer comparing this Guid (g) to other Guid. The result will be 0 if g==other, -1 if this g < other, and +1 if g > other.

--- a/sttp/guid/Guid.go
+++ b/sttp/guid/Guid.go
@@ -25,6 +25,7 @@ package guid
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"strconv"
 
@@ -98,18 +99,10 @@ func result(left, right uint32) int {
 
 // Components gets the Guid value as its constituent components.
 func (g Guid) Components() (a uint32, b, c uint16, d [8]byte) {
-	a = (uint32(g[0]) << 24) | (uint32(g[1]) << 16) | (uint32(g[2]) << 8) | uint32(g[3])
-	b = uint16((uint32(g[4]) << 8) | uint32(g[5]))
-	c = uint16((uint32(g[6]) << 8) | uint32(g[7]))
-	d[0] = g[8]
-	d[1] = g[9]
-	d[2] = g[10]
-	d[3] = g[11]
-	d[4] = g[12]
-	d[5] = g[13]
-	d[6] = g[14]
-	d[7] = g[15]
-
+	a = binary.BigEndian.Uint32(g[:4])
+	b = binary.BigEndian.Uint16(g[4:6])
+	c = binary.BigEndian.Uint16(g[6:8])
+	copy(d[:], g[8:16])
 	return
 }
 

--- a/sttp/guid/Guid.go
+++ b/sttp/guid/Guid.go
@@ -131,9 +131,7 @@ func FromBytes(data []byte, swapEndianness bool) (Guid, error) {
 		swapGuidEndianness(&data)
 	}
 
-	var g Guid
-	copy(g[:], data[:16])
-	return g, nil
+	return Guid(data), nil
 }
 
 // ToBytes creates a byte slice from a Guid.

--- a/sttp/guid/Guid.go
+++ b/sttp/guid/Guid.go
@@ -50,7 +50,11 @@ func (g Guid) IsZero() bool {
 
 // Equal returns true if this Guid and other Guid values are equal.
 func (g Guid) Equal(other Guid) bool {
-	return Equal(g, other)
+	a1 := (*uint64)(unsafe.Pointer(&g[0]))
+	a2 := (*uint64)(unsafe.Pointer(&g[8]))
+	b1 := (*uint64)(unsafe.Pointer(&other[0]))
+	b2 := (*uint64)(unsafe.Pointer(&other[8]))
+	return *a1 == *b1 && *a2 == *b2
 }
 
 // Equal returns true if the a and b Guid values are equal.

--- a/sttp/guid/Guid_test.go
+++ b/sttp/guid/Guid_test.go
@@ -26,6 +26,7 @@ package guid
 import (
 	"bytes"
 	"testing"
+	"unsafe"
 )
 
 const (
@@ -310,48 +311,38 @@ func testGuidToFromBytes(g Guid, gs string, swapEndianness bool, t *testing.T) {
 }
 
 func BenchmarkEqualityBaseline(b *testing.B) {
-	list := []string{gs1,gs2,gs3,gs4,gs5,gs6,gsz}
+	list := []string{gs1, gs2, gs3, gs4, gs5, gs6, gsz}
 	glist := [7]Guid{}
 	for i := range list {
 		glist[i], _ = Parse(list[i])
 	}
 	b.ResetTimer()
 	for range b.N {
-		for i := range list {
-			for j := range list {
-				if i == j {
-					continue
-				}
-				equal := true
-				a, b := glist[i], glist[j]
-				for k := range 16 {
-					if a[k] != b[k] {
-						equal = false
-						break
-					}
-				}
-				_ = equal
+		equal := true
+		a, b := glist[0], glist[1]
+		for k := range 16 {
+			if a[k] != b[k] {
+				equal = false
+				break
 			}
 		}
+		_ = equal
 	}
 }
 
 func BenchmarkEqualityCurrent(b *testing.B) {
-	list := []string{gs1,gs2,gs3,gs4,gs5,gs6,gsz}
+	list := []string{gs1, gs2, gs3, gs4, gs5, gs6, gsz}
 	glist := [7]Guid{}
 	for i := range list {
 		glist[i], _ = Parse(list[i])
 	}
 	b.ResetTimer()
 	for range b.N {
-		for i := range list {
-			for j := range list {
-				if i == j {
-					continue
-				}
-				_ = glist[i].Equal(glist[j])
-			}
-		}
+		a1 := (*uint64)(unsafe.Pointer(&glist[0][0]))
+		a2 := (*uint64)(unsafe.Pointer(&glist[0][8]))
+		b1 := (*uint64)(unsafe.Pointer(&glist[1][0]))
+		b2 := (*uint64)(unsafe.Pointer(&glist[1][8]))
+		equal := *a1 == *b1 && *a2 == *b2
+		_ = equal
 	}
 }
-

--- a/sttp/guid/Guid_test.go
+++ b/sttp/guid/Guid_test.go
@@ -346,3 +346,16 @@ func BenchmarkEqualityCurrent(b *testing.B) {
 		_ = equal
 	}
 }
+
+func BenchmarkEqualityDirect(b *testing.B) {
+	list := []string{gs1, gs2, gs3, gs4, gs5, gs6, gsz}
+	glist := [7]Guid{}
+	for i := range list {
+		glist[i], _ = Parse(list[i])
+	}
+	b.ResetTimer()
+	for range b.N {
+		equal := glist[0] == glist[1]
+		_ = equal
+	}
+}

--- a/sttp/guid/Guid_test.go
+++ b/sttp/guid/Guid_test.go
@@ -25,7 +25,6 @@ package guid
 
 import (
 	"bytes"
-	"strconv"
 	"testing"
 )
 
@@ -39,7 +38,7 @@ const (
 	gsz string = "{00000000-0000-0000-0000-000000000000}"
 )
 
-//gocyclo: ignore
+// gocyclo: ignore
 func TestGuidParsing(t *testing.T) {
 	var g1, g2, g3, g4 Guid
 	var err error
@@ -113,12 +112,12 @@ func TestGuidParsing(t *testing.T) {
 func TestNewGuidRandomness(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		if New().Equal(New()) || Equal(New(), New()) {
-			t.Fatalf("TestNewGuidRandomness: encountered non-unique Guid after " + strconv.Itoa(i*4) + "generations")
+			t.Fatalf("TestNewGuidRandomness: encountered non-unique Guid after %d generations", i*4)
 		}
 	}
 }
 
-//gocyclo: ignore
+// gocyclo: ignore
 func TestZeroGuid(t *testing.T) {
 	var gz, zero Guid
 	var err error
@@ -166,7 +165,7 @@ func TestZeroGuid(t *testing.T) {
 	}
 }
 
-//gocyclo: ignore
+// gocyclo: ignore
 func TestGuidCompare(t *testing.T) {
 	var g1, g2, g3, g4, g5, g6 Guid
 	var err error
@@ -296,16 +295,16 @@ func testGuidToFromBytes(g Guid, gs string, swapEndianness bool, t *testing.T) {
 	}
 
 	if !bytes.Equal(gbf, gbs) {
-		t.Fatalf("TestGuidToFromBytes: ToBytes test compare failed for guid " + gs)
+		t.Fatal("TestGuidToFromBytes: ToBytes test compare failed for guid " + gs)
 	}
 
 	g1fb, err := FromBytes(gbf, swapEndianness)
 
 	if err != nil {
-		t.Fatalf("TestGuidToFromBytes: FromBytes failed for guid " + gs)
+		t.Fatal("TestGuidToFromBytes: FromBytes failed for guid " + gs)
 	}
 
 	if !g1fb.Equal(g) {
-		t.Fatalf("TestGuidToFromBytes: FromBytes test compare failed for guid " + gs)
+		t.Fatal("TestGuidToFromBytes: FromBytes test compare failed for guid " + gs)
 	}
 }

--- a/sttp/guid/Guid_test.go
+++ b/sttp/guid/Guid_test.go
@@ -308,3 +308,50 @@ func testGuidToFromBytes(g Guid, gs string, swapEndianness bool, t *testing.T) {
 		t.Fatal("TestGuidToFromBytes: FromBytes test compare failed for guid " + gs)
 	}
 }
+
+func BenchmarkEqualityBaseline(b *testing.B) {
+	list := []string{gs1,gs2,gs3,gs4,gs5,gs6,gsz}
+	glist := [7]Guid{}
+	for i := range list {
+		glist[i], _ = Parse(list[i])
+	}
+	b.ResetTimer()
+	for range b.N {
+		for i := range list {
+			for j := range list {
+				if i == j {
+					continue
+				}
+				equal := true
+				a, b := glist[i], glist[j]
+				for k := range 16 {
+					if a[k] != b[k] {
+						equal = false
+						break
+					}
+				}
+				_ = equal
+			}
+		}
+	}
+}
+
+func BenchmarkEqualityCurrent(b *testing.B) {
+	list := []string{gs1,gs2,gs3,gs4,gs5,gs6,gsz}
+	glist := [7]Guid{}
+	for i := range list {
+		glist[i], _ = Parse(list[i])
+	}
+	b.ResetTimer()
+	for range b.N {
+		for i := range list {
+			for j := range list {
+				if i == j {
+					continue
+				}
+				_ = glist[i].Equal(glist[j])
+			}
+		}
+	}
+}
+

--- a/sttp/guid/Guid_test.go
+++ b/sttp/guid/Guid_test.go
@@ -310,6 +310,53 @@ func testGuidToFromBytes(g Guid, gs string, swapEndianness bool, t *testing.T) {
 	}
 }
 
+func (g Guid) EqualIndirectBaseline(other Guid) bool {
+	return EqualBaseline(g, other)
+}
+
+func (g Guid) EqualIndirect(other Guid) bool {
+	return Equal(g, other)
+}
+
+func EqualBaseline(a, b Guid) bool {
+	for k := range 16 {
+		if a[k] != b[k] {
+			return false
+			break
+		}
+	}
+	return true
+
+}
+
+func BenchmarkEqualityIndirect(b *testing.B) {
+	list := []string{gs1, gs2, gs3, gs4, gs5, gs6, gsz}
+	glist := [7]Guid{}
+	for i := range list {
+		glist[i], _ = Parse(list[i])
+	}
+	b.ResetTimer()
+	for range b.N {
+		a, b := glist[0], glist[1]
+		equal := a.EqualIndirect(b)
+		_ = equal
+	}
+}
+
+func BenchmarkEqualityIndirectBaseline(b *testing.B) {
+	list := []string{gs1, gs2, gs3, gs4, gs5, gs6, gsz}
+	glist := [7]Guid{}
+	for i := range list {
+		glist[i], _ = Parse(list[i])
+	}
+	b.ResetTimer()
+	for range b.N {
+		a, b := glist[0], glist[1]
+		equal := a.EqualIndirectBaseline(b)
+		_ = equal
+	}
+}
+
 func BenchmarkEqualityBaseline(b *testing.B) {
 	list := []string{gs1, gs2, gs3, gs4, gs5, gs6, gsz}
 	glist := [7]Guid{}


### PR DESCRIPTION
guid.Equal() is slow. We call it in a hot loop, and it shows up as a significant part of the profile for one component.

Added benchmarking, and tested a few different approaches. Was reminded by a coworker that `==` is valid for arrays in Go, and the compiler does a great job: 

```
noam@sylphrena ~/pingthings/goapi/sttp/guid $ go test -bench .
goos: linux
goarch: amd64
pkg: github.com/sttp/goapi/sttp/guid
cpu: AMD Ryzen 9 7900X3D 12-Core Processor          
BenchmarkEqualityIndirect-24            	1000000000	        0.7779 ns/op
BenchmarkEqualityIndirectBaseline-24    	152718645	        7.887 ns/op
BenchmarkEqualityBaseline-24            	179326930	        6.897 ns/op
BenchmarkEqualityCurrent-24             	1000000000	        0.1949 ns/op
BenchmarkEqualityDirect-24              	1000000000	        0.1936 ns/op
PASS
ok  	github.com/sttp/goapi/sttp/guid	5.221s
```

The current approach has two problems:

- First, the for loop approach is _slow_. It's hypothetically optimizable, but `a == b` works just fine for Guids and is ~35x faster.
- Secondly, the indirection, while theoretically inlinable, is not being inlined. With the for loop, it adds 1ns/op - from 6.9 to 7.9 - but with the `a == b` approach, it adds 0.6ns - from 0.2 to 0.8ns.

Fixing both improves overall throughput from 8ns/op to 0.2ns/op, a ~40x improvement.

I fixed both APIs rather than remove one just so there's no breakage and it's easier to get reviewed.